### PR TITLE
Github action to zip up git lfs files and add to releases

### DIFF
--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -1,0 +1,29 @@
+name: Generate Zip File
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+        path: owl-examples
+        submodules: true
+    - name: zip up contents
+      shell: bash
+      run: |
+        VERSION=`echo "$GITHUB_REF_NAME" | sed "s%/%.%g"`
+        ZIP_FILE_NAME=owl-examples.$VERSION.zip
+        zip -8 -r $ZIP_FILE_NAME owl-examples -x '*.git*'
+        echo "zip_file_name=$ZIP_FILE_NAME" >> $GITHUB_ENV
+
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "${{ env.zip_file_name }}" 


### PR DESCRIPTION
Add an `on-tag` action to generate a zip file with all of the repo whenever a tag is pushed to the repository